### PR TITLE
Update NXP repositories, fix image size calculation

### DIFF
--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -30,7 +30,7 @@ for rootfs in *.rootfs.tar.xz; do
 
     # Create an empty disk image
     img="../images/$(basename "${rootfs}" .rootfs.tar.xz).img"
-    size="$(xz -l "${rootfs}" | tail -n +2 | sed 's/,//g' | awk '{print int($5 + 1)}')"
+    size="$(xz --robot -l "${rootfs}" | tail -n +2 | awk '{print int($5/1048576 + 1)}')"
     truncate -s "$(( size + 2048 + 512 ))M" "${img}"
 
     # Create loop device for disk image

--- a/scripts/build-imx-boot.sh
+++ b/scripts/build-imx-boot.sh
@@ -56,7 +56,7 @@ cd ..
 
 # Download and build the boot container
 if [ ! -d imx-mkimage ]; then
-    git clone --depth=1 --progress -b imx_5.4.70_2.3.0 https://source.codeaurora.org/external/imx/imx-mkimage/
+    git clone --depth=1 --progress -b imx_5.4.70_2.3.0 https://github.com/nxp-imx/imx-mkimage/
 fi
 cd imx-mkimage
 cp ../imx-seco-3.8.1/firmware/seco/mx8qmb0-ahab-container.img iMX8QM/mx8qmb0-ahab-container.img


### PR DESCRIPTION
Update ./scripts/build-imx-boot.sh to point to the new NXP repository.
Update ./scripts/build-imx-boot.sh to calculate image size correctly on any host system independently of regional settings